### PR TITLE
Correção do tipo de desconto padrão para incondicional

### DIFF
--- a/src/Shared.MotorTributarioNet/Facade/FacadeCalculadoraTributacao.cs
+++ b/src/Shared.MotorTributarioNet/Facade/FacadeCalculadoraTributacao.cs
@@ -85,5 +85,10 @@ namespace MotorTributarioNet.Facade
         {
             return new TributacaoFcpSt(_tributavel, _tipoDesconto).Calcula();
         }
+
+        public IResultadoCalculoIssqn CalculaIssqn(bool calcularRetencao)
+        {
+            return new TributacaoIssqn(_tributavel, _tipoDesconto).Calcula(calcularRetencao);
+        }
     }
 }

--- a/src/Shared.MotorTributarioNet/Impostos/IResultadoCalculoIssqn.cs
+++ b/src/Shared.MotorTributarioNet/Impostos/IResultadoCalculoIssqn.cs
@@ -22,6 +22,7 @@ namespace MotorTributarioNet.Impostos
 {
     public interface IResultadoCalculoIssqn
     {
+        decimal BaseCalculo { get; }
         decimal BaseCalculoInss { get; set; }
         decimal Valor { get; set; }
         decimal BaseCalculoIrrf { get; set; }       

--- a/src/Shared.MotorTributarioNet/Impostos/ResultadoTributacao.cs
+++ b/src/Shared.MotorTributarioNet/Impostos/ResultadoTributacao.cs
@@ -33,6 +33,7 @@ namespace MotorTributarioNet.Impostos
     {
         #region Impostos Privados  
 
+        private TipoDesconto TipoDesconto { get; set; }
         private TipoPessoa TipoPessoa { get; set; }
         private TipoOperacao Operacao { get; set; }
         private Crt CrtEmpresa { get; set; }
@@ -102,12 +103,13 @@ namespace MotorTributarioNet.Impostos
         #endregion
 
         private readonly ITributavelProduto _produto;
-        public ResultadoTributacao(ITributavelProduto produto, Crt crtEmpresa, TipoOperacao operacao, TipoPessoa tipoPessoa)
+        public ResultadoTributacao(ITributavelProduto produto, Crt crtEmpresa, TipoOperacao operacao, TipoPessoa tipoPessoa, TipoDesconto tipoDesconto = TipoDesconto.Incondicional)
         {
             _produto = produto;
             CrtEmpresa = crtEmpresa;
             Operacao = operacao;
             TipoPessoa = tipoPessoa;
+            TipoDesconto = tipoDesconto;
         }
 
         public ResultadoTributacao Calcular()
@@ -389,7 +391,7 @@ namespace MotorTributarioNet.Impostos
 
         private TributacaoIpi CalcularIpi()
         {
-            Ipi = new TributacaoIpi(_produto, TipoDesconto.Condincional);
+            Ipi = new TributacaoIpi(_produto, TipoDesconto);
             ValorIpi = decimal.Zero;
             ValorBcIpi = decimal.Zero;
 
@@ -407,7 +409,7 @@ namespace MotorTributarioNet.Impostos
 
         private TributacaoPis CalcularPis()
         {
-            Pis = new TributacaoPis(_produto, TipoDesconto.Condincional);
+            Pis = new TributacaoPis(_produto, TipoDesconto);
             ValorPis = decimal.Zero;
             ValorBcPis = decimal.Zero;
 
@@ -423,7 +425,7 @@ namespace MotorTributarioNet.Impostos
 
         private TributacaoCofins CalcularCofins()
         {
-            Cofins = new TributacaoCofins(_produto, TipoDesconto.Condincional);
+            Cofins = new TributacaoCofins(_produto, TipoDesconto);
             ValorCofins = decimal.Zero;
             ValorBcCofins = decimal.Zero;
 
@@ -440,7 +442,7 @@ namespace MotorTributarioNet.Impostos
 
         private TributacaoIssqn CalcularIssqn(bool calcularRetencao)
         {
-            Issqn = new TributacaoIssqn(_produto, TipoDesconto.Condincional);
+            Issqn = new TributacaoIssqn(_produto, TipoDesconto);
             var result = Issqn.Calcula(calcularRetencao);
             BaseCalculoInss = result.BaseCalculoInss;
             BaseCalculoIrrf = result.BaseCalculoIrrf;
@@ -455,7 +457,7 @@ namespace MotorTributarioNet.Impostos
 
         private TributacaoFcp CalcularFcp()
         {
-            TributacaoFcp = new TributacaoFcp(_produto, TipoDesconto.Condincional);
+            TributacaoFcp = new TributacaoFcp(_produto, TipoDesconto);
             Fcp = decimal.Zero;
             ValorBcFcp = decimal.Zero;
 
@@ -470,7 +472,7 @@ namespace MotorTributarioNet.Impostos
         private TributacaoDifal CalcularDifal()
         {
             var cstCson = (Crt.RegimeNormal == CrtEmpresa ? _produto.Cst.GetValue<int>() : _produto.Csosn.GetValue<int>());
-            Difal = new TributacaoDifal(_produto, TipoDesconto.Condincional);
+            Difal = new TributacaoDifal(_produto, TipoDesconto);
             ValorBcDifal = decimal.Zero;
             ValorDifal = decimal.Zero;
             ValorIcmsOrigem = decimal.Zero;

--- a/src/TestMotorTributarioNet/CalculoCofinsTest.cs
+++ b/src/TestMotorTributarioNet/CalculoCofinsTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MotorTributarioNet.Facade;
+using MotorTributarioNet.Flags;
 using TestCalculosTributarios.Entidade;
 
 namespace TestCalculosTributarios
@@ -27,6 +28,25 @@ namespace TestCalculosTributarios
         }
 
         [TestMethod]
+        public void CalculaCofinsComDescontoIncondicional()
+        {
+            var produto = new Produto
+            {
+                PercentualCofins = 0.65m,
+                ValorProduto = 1000.00m,
+                QuantidadeProduto = 1.000m,
+                Desconto = 100.00m
+            };
+
+            var facade = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
+
+            var resultadoCalculoCofins = facade.CalculaCofins();
+
+            Assert.AreEqual(900.00m, resultadoCalculoCofins.BaseCalculo);
+            Assert.AreEqual(5.85m, resultadoCalculoCofins.Valor);
+        }
+
+        [TestMethod]
         public void CalculaCofinsMaisIpi()
         {
             var produto = new Produto
@@ -46,6 +66,26 @@ namespace TestCalculosTributarios
         }
 
         [TestMethod]
+        public void CalculaCofinsMaisIpiComDescontoIncondicional()
+        {
+            var produto = new Produto
+            {
+                PercentualCofins = 0.65m,
+                ValorProduto = 1000.00m,
+                QuantidadeProduto = 1.000m,
+                ValorIpi = 10,
+                Desconto = 100.00m
+            };
+
+            var facade = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
+
+            var resultadoCalculoCofins = facade.CalculaCofins();
+
+            Assert.AreEqual(910.00m, resultadoCalculoCofins.BaseCalculo);
+            Assert.AreEqual(5.92m, decimal.Round(resultadoCalculoCofins.Valor, 2));
+        }
+
+        [TestMethod]
         public void CalculaCofinsComIpiZero()
         {
             var produto = new Produto
@@ -62,6 +102,26 @@ namespace TestCalculosTributarios
 
             Assert.AreEqual(1000.00m, resultadoCalculoCofins.BaseCalculo);
             Assert.AreEqual(6.50m, resultadoCalculoCofins.Valor);
+        }
+
+        [TestMethod]
+        public void CalculaCofinsComIpiZeroComDescontoIncondicional()
+        {
+            var produto = new Produto
+            {
+                PercentualCofins = 0.65m,
+                ValorProduto = 1000.00m,
+                QuantidadeProduto = 1.000m,
+                ValorIpi = 0,
+                Desconto = 100.00m
+            };
+
+            var facade = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
+
+            var resultadoCalculoCofins = facade.CalculaCofins();
+
+            Assert.AreEqual(900.00m, resultadoCalculoCofins.BaseCalculo);
+            Assert.AreEqual(5.85m, resultadoCalculoCofins.Valor);
         }
     }
 }

--- a/src/TestMotorTributarioNet/CalculoFcpStTest.cs
+++ b/src/TestMotorTributarioNet/CalculoFcpStTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MotorTributarioNet.Facade;
+using MotorTributarioNet.Flags;
 using TestCalculosTributarios.Entidade;
 
 namespace TestCalculosTributarios
@@ -24,7 +25,7 @@ namespace TestCalculosTributarios
             
             Assert.AreEqual(56.00m, resultadoCalculoIcmsSt.ValorFcpSt);
         }
-
+        
         [TestMethod] // https://portalspedbrasil.com.br/forum/fundo-do-combate-a-probreza-icms-normal-e-fcp-st/
         public void TestFcpSt_Valor_2_60()
         {
@@ -41,6 +42,26 @@ namespace TestCalculosTributarios
             var resultadoCalculoIcmsSt = facade.CalculaFcpSt();
 
             Assert.AreEqual(2.60m, resultadoCalculoIcmsSt.ValorFcpSt);
+        }
+
+        [TestMethod]
+        public void TestaFcpSt_ComDescontoIncondicional()
+        {
+            var produto = new Produto
+            {
+                PercentualFcpSt = 2.00m,
+                ValorProduto = 2000.00m,
+                QuantidadeProduto = 1.000m,
+                PercentualMva = 40.00m,
+                Desconto = 200.00m
+            };
+
+            var facade = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
+
+            var resultadoCalculoIcmsSt = facade.CalculaFcpSt();
+
+            Assert.AreEqual(2520.00m, resultadoCalculoIcmsSt.BaseCalculoFcpSt);
+            Assert.AreEqual(50.40m, resultadoCalculoIcmsSt.ValorFcpSt);
         }
     }
 }

--- a/src/TestMotorTributarioNet/CalculoFcpTest.cs
+++ b/src/TestMotorTributarioNet/CalculoFcpTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MotorTributarioNet.Facade;
+using MotorTributarioNet.Flags;
 using TestCalculosTributarios.Entidade;
 
 namespace TestCalculosTributarios
@@ -23,6 +24,25 @@ namespace TestCalculosTributarios
 
             Assert.AreEqual(1000.00m, resultadoCalculoCofins.BaseCalculo);
             Assert.AreEqual(100.00m, resultadoCalculoCofins.Valor);
+        }
+
+        [TestMethod]
+        public void TestaCalculoFcpComDescontoIncondicional()
+        {
+            var produto = new Produto
+            {
+                PercentualFcp = 10,
+                ValorProduto = 1000.00m,
+                QuantidadeProduto = 1.000m,
+                Desconto = 100
+            };
+
+            var facade = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
+
+            var resultadoCalculoCofins = facade.CalculaFcp();
+
+            Assert.AreEqual(900.00m, resultadoCalculoCofins.BaseCalculo);
+            Assert.AreEqual(90.00m, resultadoCalculoCofins.Valor);
         }
     }
 }

--- a/src/TestMotorTributarioNet/CalculoIpiTest.cs
+++ b/src/TestMotorTributarioNet/CalculoIpiTest.cs
@@ -64,7 +64,26 @@ namespace TestCalculosTributarios
         }
 
         [TestMethod]
-        public void CalcularIpiComFrete()
+        public void CalcularIpiComDescontoIncondicional()
+        {
+            var produto = new Produto
+            {
+                PercentualIpi = 12.00m,
+                ValorProduto = 2000.00m,
+                QuantidadeProduto = 2.000m,
+                Desconto = 1000.00m
+            };
+
+            var facade = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
+
+            var resultadoCalculoIpi = facade.CalculaIpi();
+
+            Assert.AreEqual(3000.00m, resultadoCalculoIpi.BaseCalculo);
+            Assert.AreEqual(360.00m, resultadoCalculoIpi.Valor);
+        }
+
+        [TestMethod]
+        public void CalcularIpiComFreteComDescontoCondicional()
         {
             var produto = new Produto
             {
@@ -84,7 +103,27 @@ namespace TestCalculosTributarios
         }
 
         [TestMethod]
-        public void CalcularIpiComOutrasDespesasESeguro()
+        public void CalcularIpiComFreteComDescontoIncondicional()
+        {
+            var produto = new Produto
+            {
+                PercentualIpi = 15.00m,
+                ValorProduto = 2000m,
+                QuantidadeProduto = 2.000m,
+                Desconto = 1000.00m,
+                Frete = 373.50m
+            };
+
+            var facade = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
+
+            var resultadoCalculoIpi = facade.CalculaIpi();
+
+            Assert.AreEqual(3373.50m, decimal.Round(resultadoCalculoIpi.BaseCalculo, 2));
+            Assert.AreEqual(506.02m, decimal.Round(resultadoCalculoIpi.Valor, 2));
+        }
+
+        [TestMethod]
+        public void CalcularIpiComOutrasDespesasESeguroComDescontoCondicional()
         {
             var produto = new Produto
             {
@@ -103,6 +142,28 @@ namespace TestCalculosTributarios
 
             Assert.AreEqual(5612.33m, decimal.Round(resultadoCalculoIpi.BaseCalculo, 2));
             Assert.AreEqual(673.48m, decimal.Round(resultadoCalculoIpi.Valor, 2));
+        }
+
+        [TestMethod]
+        public void CalcularIpiComOutrasDespesasESeguroComDescontoIncondicional()
+        {
+            var produto = new Produto
+            {
+                PercentualIpi = 12.00m,
+                ValorProduto = 2000m,
+                QuantidadeProduto = 2.000m,
+                Desconto = 1000.00m,
+                Frete = 373.50m,
+                OutrasDespesas = 233.10m,
+                Seguro = 5.73m
+            };
+
+            var facade = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
+
+            var resultadoCalculoIpi = facade.CalculaIpi();
+
+            Assert.AreEqual(3612.33m, decimal.Round(resultadoCalculoIpi.BaseCalculo, 2));
+            Assert.AreEqual(433.48m, decimal.Round(resultadoCalculoIpi.Valor, 2));
         }
     }
 }

--- a/src/TestMotorTributarioNet/CalculoIssqnTest.cs
+++ b/src/TestMotorTributarioNet/CalculoIssqnTest.cs
@@ -1,0 +1,122 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MotorTributarioNet.Facade;
+using MotorTributarioNet.Flags;
+using TestCalculosTributarios.Entidade;
+
+
+namespace TestCalculosTributarios
+{
+    [TestClass]
+    public class CalculoIssqnTest
+    {
+        [TestMethod]
+        public void CalculoIssqn()
+        {
+            var produto = new Produto
+            {
+                ValorProduto = 1000.00m,
+                QuantidadeProduto = 1.000m,
+                IsServico = true,
+                PercentualIssqn = 5.00m
+            };
+
+            var facade = new FacadeCalculadoraTributacao(produto);
+
+            var resultadoCalculoIssqn = facade.CalculaIssqn(false);
+
+            Assert.AreEqual(1000.00m, resultadoCalculoIssqn.BaseCalculo);
+            Assert.AreEqual(50.00m, resultadoCalculoIssqn.Valor);
+        }
+
+        [TestMethod]
+        public void CalculoIssqnComDescontoIncondicional()
+        {
+            var produto = new Produto
+            {
+                ValorProduto = 1000.00m,
+                QuantidadeProduto = 1.000m,
+                IsServico = true,
+                PercentualIssqn = 5.00m,
+                Desconto = 100.00m
+            };
+
+            var facade = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
+
+            var resultadoCalculoIssqn = facade.CalculaIssqn(false);
+
+            Assert.AreEqual(900.00m, resultadoCalculoIssqn.BaseCalculo);
+            Assert.AreEqual(45.00m, resultadoCalculoIssqn.Valor);
+        }
+
+        [TestMethod]
+        public void CalculoIssqnComRetencao()
+        {
+            var produto = new Produto
+            {
+
+                ValorProduto = 1000.00m,
+                QuantidadeProduto = 1.000m,
+                IsServico = true,
+                PercentualIssqn = 5.00m,
+
+                PercentualRetIrrf = 1.65m,
+                PercentualRetCsll = 1.00m,
+                PercentualRetCofins = 3.00m,
+                PercentualRetPis = 0.65m,
+                PercentualRetInss = 11.00m
+            };
+
+            var facade = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
+
+            var resultadoCalculoIssqn = facade.CalculaIssqn(true);
+
+            Assert.AreEqual(1000.00m, resultadoCalculoIssqn.BaseCalculo);
+            Assert.AreEqual(50.00m, resultadoCalculoIssqn.Valor);
+
+            Assert.AreEqual(1000.00m, resultadoCalculoIssqn.BaseCalculoInss);
+            Assert.AreEqual(1000.00m, resultadoCalculoIssqn.BaseCalculoIrrf);
+
+            Assert.AreEqual(16.50m, resultadoCalculoIssqn.ValorRetIrrf);
+            Assert.AreEqual(30.00m, resultadoCalculoIssqn.ValorRetCofins);
+            Assert.AreEqual(6.50m, resultadoCalculoIssqn.ValorRetPis);
+            Assert.AreEqual(110.00m, resultadoCalculoIssqn.ValorRetInss);
+            Assert.AreEqual(10.00m, resultadoCalculoIssqn.ValorRetCsll);
+        }
+
+        [TestMethod]
+        public void CalculoIssqnComRetencaoComDescontoIncondicional()
+        {
+            var produto = new Produto
+            {
+
+                ValorProduto = 1000.00m,
+                QuantidadeProduto = 1.000m,
+                IsServico = true,
+                PercentualIssqn = 5.00m,
+                Desconto = 100.00m,
+
+                PercentualRetIrrf = 1.65m,
+                PercentualRetCsll = 1.00m,
+                PercentualRetCofins = 3.00m,
+                PercentualRetPis = 0.65m,
+                PercentualRetInss = 11.00m
+            };
+
+            var facade = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
+
+            var resultadoCalculoIssqn = facade.CalculaIssqn(true);
+
+            Assert.AreEqual(900.00m, resultadoCalculoIssqn.BaseCalculo);
+            Assert.AreEqual(45.00m, resultadoCalculoIssqn.Valor);
+
+            Assert.AreEqual(900.00m, resultadoCalculoIssqn.BaseCalculoInss);
+            Assert.AreEqual(900.00m, resultadoCalculoIssqn.BaseCalculoIrrf);
+
+            Assert.AreEqual(14.85m, resultadoCalculoIssqn.ValorRetIrrf);
+            Assert.AreEqual(27.00m, resultadoCalculoIssqn.ValorRetCofins);
+            Assert.AreEqual(5.85m, resultadoCalculoIssqn.ValorRetPis);
+            Assert.AreEqual(99.00m, resultadoCalculoIssqn.ValorRetInss);
+            Assert.AreEqual(9.00m, resultadoCalculoIssqn.ValorRetCsll);
+        }
+    }
+}

--- a/src/TestMotorTributarioNet/CalculoPisTest.cs
+++ b/src/TestMotorTributarioNet/CalculoPisTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MotorTributarioNet.Facade;
+using MotorTributarioNet.Flags;
 using TestCalculosTributarios.Entidade;
 
 namespace TestCalculosTributarios
@@ -10,8 +11,7 @@ namespace TestCalculosTributarios
 
         [TestMethod]
         public void CalculoPis()
-        {
-            
+        {            
             var produto = new Produto
             {
                 PercentualPis = 1.65m,
@@ -28,9 +28,27 @@ namespace TestCalculosTributarios
         }
 
         [TestMethod]
+        public void CalculoPisComDescontoIncondicional()
+        {
+            var produto = new Produto
+            {
+                PercentualPis = 1.65m,
+                ValorProduto = 1000.00m,
+                QuantidadeProduto = 1.000m,
+                Desconto = 100.00m
+            };
+
+            var facade = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
+
+            var resultadoCalculoPis = facade.CalculaPis();
+
+            Assert.AreEqual(900.00m, resultadoCalculoPis.BaseCalculo);
+            Assert.AreEqual(14.85m, resultadoCalculoPis.Valor);
+        }
+
+        [TestMethod]
         public void CalculoPisComIpi()
         {
-
             var produto = new Produto
             {
                 PercentualPis = 1.65m,
@@ -48,9 +66,28 @@ namespace TestCalculosTributarios
         }
 
         [TestMethod]
+        public void CalculoPisComIpiComDescontoIncondicional()
+        {
+            var produto = new Produto
+            {
+                PercentualPis = 1.65m,
+                ValorProduto = 1000.00m,
+                QuantidadeProduto = 1.000m,
+                ValorIpi = 10,
+                Desconto = 100.00m
+            };
+
+            var facade = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
+
+            var resultadoCalculoPis = facade.CalculaPis();
+
+            Assert.AreEqual(910.00m, resultadoCalculoPis.BaseCalculo);
+            Assert.AreEqual(15.02m, decimal.Round(resultadoCalculoPis.Valor, 2));
+        }
+
+        [TestMethod]
         public void CalculoPisComIpiZero()
         {
-
             var produto = new Produto
             {
                 PercentualPis = 1.65m,
@@ -65,6 +102,26 @@ namespace TestCalculosTributarios
 
             Assert.AreEqual(1000.00m, resultadoCalculoPis.BaseCalculo);
             Assert.AreEqual(16.50m, resultadoCalculoPis.Valor);
+        }
+
+        [TestMethod]
+        public void CalculoPisComIpiZeroComDescontoIncondicional()
+        {
+            var produto = new Produto
+            {
+                PercentualPis = 1.65m,
+                ValorProduto = 1000.00m,
+                QuantidadeProduto = 1.000m,
+                ValorIpi = 0,
+                Desconto = 100.00m
+            };
+
+            var facade = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
+
+            var resultadoCalculoPis = facade.CalculaPis();
+
+            Assert.AreEqual(900.00m, resultadoCalculoPis.BaseCalculo);
+            Assert.AreEqual(14.85m, resultadoCalculoPis.Valor);
         }
 
     }

--- a/src/TestMotorTributarioNet/TestMotorTributarioNet.csproj
+++ b/src/TestMotorTributarioNet/TestMotorTributarioNet.csproj
@@ -61,6 +61,7 @@
     <Compile Include="CalculoIcmsStTest.cs" />
     <Compile Include="CalculoIcmsTest.cs" />
     <Compile Include="CalculoIpiTest.cs" />
+    <Compile Include="CalculoIssqnTest.cs" />
     <Compile Include="CalculoItemNFe.cs" />
     <Compile Include="CalculoPisTest.cs" />
     <Compile Include="Csosn\Csosn101Test.cs" />


### PR DESCRIPTION
Foi realizado a correção do calculo da base de calculo do PIS e COFINS, antes a base de calculo estava somando o valor de desconto, sendo que o correto seria subtrair.
Para a correção foi modificado o tipo do desconto padrão, antes era informado o tipo Condicional de forma manual no calculo, agora além de alterar o padrão para Incondicional, também foi adicionado o tipo de desconto como parâmetro opcional na utilização do Motor Tributário. 

Os detalhes foram repassados na issue https://github.com/AutomacaoNet/MotorTributarioNet/pull/23 do projeto original do [Motor Tributário](https://github.com/AutomacaoNet/MotorTributarioNet).