### PR TITLE
Liberado Versão 3.1.0

### DIFF
--- a/src/MotorTributarioNet/MotorTributarioNet.csproj
+++ b/src/MotorTributarioNet/MotorTributarioNet.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net45;net48;net6.0</TargetFrameworks>
-		<Version>3.0.0</Version>
+		<Version>3.1.0</Version>
 	</PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Liberado a versão 3.1.0 referente a issue #28 do projeto [MotorTributarioNet.](https://github.com/AutomacaoNet/MotorTributarioNet)
Liberada na issue esistemsistemas/eSistemNFCe/issues/138.
Abaixo está a descrição das alterações:

Lembrando que esse versionamento é para publicação local da DLL, pois o versionamento do pacote nuget oficial utiliza um padrão de versão diferente e não está atualizado ainda.

# Versão 3.1.0 - [27/07/2023] - Versão final para produção
- (issue #28) Implementado no cálculo de Base de Pis e base de Cofins a opção de deduzir o valor de ICMS.
